### PR TITLE
feat: update the plugin for the new feature flag payload and update t…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,8 @@ Takes `flagKey` and `appFlags` as `props`, which is an object containing list of
 
 ```jsx
 const applicationKeys = {
-  'integration-test': true,
-  'multivariate-test': 'multivariate-test-1'
+  'integration-test': { value: true, version: 3 },
+  'multivariate-test': { value: 'multivariate-test-1', version: 5 }
 }
 <FeatureFlag flagKey="multivariate-test" appFlags={applicationKeys}></FeatureFlag>
 ```
@@ -112,8 +112,8 @@ const applicationKeys = {
 
 ```js
 const applicationKeys = {
-  'multivariate-test': 'multivariate-test-2',
-  'integration-test': true
+  'multivariate-test': { value: 'multivariate-test-2', version: 1},
+  'integration-test': { value: true }
 };
 ```
 
@@ -137,8 +137,8 @@ const applicationKeys = {
 
 ```js
 const applicationKeys = {
-  'multivariate-test': 'multivariate-test-2',
-  'integration-test': true
+  'multivariate-test': { value: 'multivariate-test-2' },
+  'integration-test': { value: true }
 };
 ```
 
@@ -168,11 +168,11 @@ const applicationKeys = {
 
 ```jsx
 const appFlags = {
-  a: 'a',
-  b: 'b',
-  c: 'c',
-  d: 'd',
-  e: 'e'
+  a: { value: 'a' },
+  b: { value: 'b' },
+  c: { value: 'c' },
+  d: { value: 'd' },
+  e: { value: 'e' }
 };
 
 const UsingHooks = () => {

--- a/src/lib/FeatureFlag/index.js
+++ b/src/lib/FeatureFlag/index.js
@@ -23,7 +23,7 @@ function FeatureFlag(props) {
         return;
       }
       // if the appFlags has the flagKey, render the child
-      if (appFlags[flagKey]) {
+      if (appFlags[flagKey] && appFlags[flagKey].value) {
         childArray.push(element);
       }
       isChildPluginComponent = true;
@@ -34,7 +34,7 @@ function FeatureFlag(props) {
         console.warn('Dont Use <FeatureFalse /> among other elements/components under <FeatureFlag /> only use it with <FeatureTrue />, No mix allowed');
         return;
       }
-      if (!appFlags[flagKey]) {
+      if (!appFlags[flagKey] || (appFlags[flagKey] && !appFlags[flagKey].value)) {
         childArray.push(element);
       }
       isChildPluginComponent = true;
@@ -55,7 +55,7 @@ function FeatureFlag(props) {
     // therefore, we simply render it as its under FeatureTrue
     if (!isChildPluginComponent) {
       isNonPluginComponent = true;
-      if (appFlags[flagKey]) {
+      if (appFlags[flagKey] && appFlags[flagKey].value) {
         childArray.push(element);
       }
     }

--- a/src/lib/FeatureSwitch/index.js
+++ b/src/lib/FeatureSwitch/index.js
@@ -19,7 +19,7 @@ function FeatureSwitch(props) {
       !breakIt
     ) {
       const { condition, allowBreak } = element.props;
-      if (appFlags[flagKey] === condition) {
+      if ((appFlags[flagKey] && appFlags[flagKey].value) === condition) {
         childArray.push(element);
         breakIt = allowBreak;
       }

--- a/test/__snapshots__/react.test.js.snap
+++ b/test/__snapshots__/react.test.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Launch Darkly Plugin  FeatureFlag: should not render component if flagKey does not exist in appFlags object  1`] = `""`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should not render component if flagKey value is false in appFlags object  1`] = `""`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should not render either FeatureTrue or FeatureFalse when it gets mixed with NonPluginElement and should throw a warnring 1`] = `
+"<div>
+  Non Plugin Element
+</div>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should not render the FeatureSwitch and throw a warning when FeatureSwitch gets mixed with NonPlugin elements 1`] = `
+"<FeatureFlag appFlags={{...}} flagKey=\\"switcher\\">
+  <div id=\\"hello\\">
+    Hello
+  </div>
+</FeatureFlag>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should render component if flagKey value is true in appFlags object  1`] = `
+"<div id=\\"hello\\">
+  hello
+</div>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should render only the FeatureFalse when flagKey value is false 1`] = `
+"<FeatureFlag appFlags={{...}} flagKey=\\"b\\">
+  <FeatureFalse>
+    <div>
+      Gets rendered when flagKey value is false
+    </div>
+  </FeatureFalse>
+</FeatureFlag>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureFlag: should render only the FeatureTrue when flagKey value is true 1`] = `
+"<FeatureFlag appFlags={{...}} flagKey=\\"a\\">
+  <FeatureTrue>
+    <div>
+      Gets rendered when flagKey value is true
+    </div>
+  </FeatureTrue>
+</FeatureFlag>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureSwitch: renders the FeatureCase component that matches the flagKey  1`] = `
+"<FeatureFlag appFlags={{...}} flagKey=\\"switcher\\">
+  <FeatureSwitch flagKey=\\"switcher\\" appFlags={{...}}>
+    <FeatureCase condition=\\"switch\\" allowBreak={true}>
+      <p>
+        Multivariate Test 1 Rendered
+      </p>
+    </FeatureCase>
+  </FeatureSwitch>
+</FeatureFlag>"
+`;
+
+exports[`Launch Darkly Plugin  FeatureSwitch: renders the FeatureDefault component when the no FeatureCase found that matches the flagKey  1`] = `
+"<FeatureFlag appFlags={{...}} flagKey=\\"switcher\\">
+  <FeatureSwitch flagKey=\\"switcher\\" appFlags={{...}}>
+    <FeatureDefault>
+      <p>
+        If no conditions are met then render the default
+      </p>
+    </FeatureDefault>
+  </FeatureSwitch>
+</FeatureFlag>"
+`;

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -1,114 +1,176 @@
-/* eslint-disable indent */
 import React from 'react';
-import { expect } from 'chai';
 import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { FeatureTrue, FeatureFlag, FeatureFalse, FeatureSwitch, FeatureCase, FeatureDefault } from '../src/lib/index';
+import {
+  FeatureTrue,
+  FeatureFlag,
+  FeatureFalse,
+  FeatureSwitch,
+  FeatureCase,
+  FeatureDefault
+} from '../src/lib/index';
+
 Enzyme.configure({ adapter: new Adapter() });
 
-
-
 const appFlags = {
-  'a': true,
-  'b': true,
-  'switcher': 'switch'
+  a: {
+    value: true,
+    version: 4,
+    variation: 0,
+    trackEvents: false
+  },
+  b: {
+    value: false,
+    version: 5,
+    variation: 0,
+    trackEvents: false
+  },
+  switcher: {
+    value: 'switch',
+    version: 5,
+    variation: 0,
+    trackEvents: false
+  }
 };
 
-
-
-
 describe('Launch Darkly Plugin ', () => {
-  it('FeatureFlag: should render component with FeatureTrue ', () => {
+  it.only('FeatureFlag: should render component if flagKey value is true in appFlags object ', () => {
     const component = shallow(
       <FeatureFlag appFlags={appFlags} flagKey="a">
-        <div>hello</div>
-        <FeatureTrue><div>Hello there</div></FeatureTrue>
-
+        <div id="hello">hello</div>
       </FeatureFlag>
     );
-    expect(component.exists()).to.equal(true);
+    expect(component.exists()).toBe(true);
+    expect(component.find('#hello').exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
   });
 
-  it('FeatureFlag: should render component with FeatureTrue where flagKey doesnt much', () => {
+  it.only('FeatureFlag: should not render component if flagKey value is false in appFlags object ', () => {
     const component = shallow(
-      <FeatureFlag appFlags={appFlags} flagKey="asdf">
-        <div>hello</div>
-        <FeatureTrue><div>Hello there</div></FeatureTrue>
-
+      <FeatureFlag appFlags={appFlags} flagKey="b">
+        <div id="hello">hello</div>
       </FeatureFlag>
     );
-    expect(component.exists()).to.equal(false);
+    expect(component.exists()).toBe(false);
+    expect(component.debug()).toMatchSnapshot();
   });
 
-  it('FeatureFlag: should render component with FeatureTrue and NonPluginElement should throw error', () => {
-    const component = mount(
-      <FeatureFlag appFlags={appFlags} flagKey="a">
-        <FeatureTrue><div>Hello there</div></FeatureTrue>
-        <div>Non Plugin Element</div>
-        <FeatureTrue><div>Hello there</div></FeatureTrue>
-      </FeatureFlag>
-    );
-    expect(component.exists()).to.equal(true);
-  });
-
-  it('FeatureFlag: should render component with FeatureFalse ', () => {
+  it.only('FeatureFlag: should not render component if flagKey does not exist in appFlags object ', () => {
     const component = shallow(
-      <FeatureFlag appFlags={appFlags} flagKey="a">
-        <div>hello</div>
-        <FeatureFalse><div>Hello there</div></FeatureFalse>
-
-      </FeatureFlag>
-    );
-    expect(component.exists()).to.equal(true);
-  });
-  it('FeatureFlag: should render component with FeatureFalse and NonPluginElement should throw error', () => {
-    const component = mount(
       <FeatureFlag appFlags={appFlags} flagKey="c">
-        <FeatureFalse><div>Hello there</div></FeatureFalse>
+        <div id="hello">hello</div>
+      </FeatureFlag>
+    );
+    expect(component.exists()).toBe(false);
+    expect(component.debug()).toMatchSnapshot();
+  });
+
+  it.only('FeatureFlag: should render only the FeatureTrue when flagKey value is true', () => {
+    const component = mount(
+      <FeatureFlag appFlags={appFlags} flagKey="a">
+        <FeatureTrue>
+          <div>Gets rendered when flagKey value is true</div>
+        </FeatureTrue>
+        <FeatureFalse>
+          <div>Gets rendered when flagKey value is false</div>
+        </FeatureFalse>
+      </FeatureFlag>
+    );
+    expect(component.exists()).toBe(true);
+    expect(component.find('FeatureTrue').exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
+  });
+
+  it.only('FeatureFlag: should render only the FeatureFalse when flagKey value is false', () => {
+    const component = mount(
+      <FeatureFlag appFlags={appFlags} flagKey="b">
+        <FeatureTrue>
+          <div>Gets rendered when flagKey value is true</div>
+        </FeatureTrue>
+        <FeatureFalse>
+          <div>Gets rendered when flagKey value is false</div>
+        </FeatureFalse>
+      </FeatureFlag>
+    );
+    expect(component.exists()).toBe(true);
+    expect(component.find('FeatureFalse').exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
+  });
+
+  it.only('FeatureFlag: should not render either FeatureTrue or FeatureFalse when it gets mixed with NonPluginElement and should throw a warnring', () => {
+    const component = shallow(
+      <FeatureFlag appFlags={appFlags} flagKey="a">
         <div>Non Plugin Element</div>
-        <FeatureFalse><div>Hello there</div></FeatureFalse>
+        <FeatureTrue>
+          <div>Hello there</div>
+        </FeatureTrue>
       </FeatureFlag>
     );
-    expect(component.exists()).to.equal(true);
+    expect(component.exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
   });
 
-  it('FeatureSwitch: should render component ', () => {
+  it.only('FeatureSwitch: renders the FeatureCase component that matches the flagKey ', () => {
     const component = mount(
       <FeatureFlag appFlags={appFlags} flagKey="switcher">
         <FeatureSwitch>
-            <FeatureCase condition="switch" allowBreak><p>Multivariate Test 1 Rendered</p></FeatureCase>
-            <FeatureCase condition="a" allowBreak><p>Multivariate Test 2 Rendered</p></FeatureCase>
-            <FeatureDefault><p>If no conditions are met then render the default</p></FeatureDefault>
+          <FeatureCase condition="switch" allowBreak>
+            <p>Multivariate Test 1 Rendered</p>
+          </FeatureCase>
+          <FeatureCase condition="a" allowBreak>
+            <p>Multivariate Test 2 Rendered</p>
+          </FeatureCase>
+          <FeatureDefault>
+            <p>If no conditions are met then render the default</p>
+          </FeatureDefault>
         </FeatureSwitch>
       </FeatureFlag>
     );
-    expect(component.exists()).to.equal(true);
+    expect(component.exists()).toBe(true);
+    expect(component.find({ condition: 'switch' }).exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
   });
 
-  it('FeatureSwitch: should render component throws warning for mixed', () => {
-    const component = mount(
-      <FeatureFlag appFlags={appFlags} flagKey="switcher">
-        <div>Hello</div>
-        <FeatureSwitch>
-            <FeatureCase condition="switch" allowBreak><p>Multivariate Test 1 Rendered</p></FeatureCase>
-            <FeatureCase condition="a" allowBreak><p>Multivariate Test 2 Rendered</p></FeatureCase>
-            <FeatureDefault><p>If no conditions are met then render the default</p></FeatureDefault>
-        </FeatureSwitch>
-      </FeatureFlag>
-    );
-    expect(component.exists()).to.equal(true);
-  });
-
-  it('FeatureSwitch: should render component throws warning for mixed', () => {
+  it.only('FeatureSwitch: renders the FeatureDefault component when the no FeatureCase found that matches the flagKey ', () => {
     const component = mount(
       <FeatureFlag appFlags={appFlags} flagKey="switcher">
         <FeatureSwitch>
-            <FeatureCase condition="swch" allowBreak><p>Multivariate Test 1 Rendered</p></FeatureCase>
-            <FeatureCase condition="a" allowBreak><p>Multivariate Test 2 Rendered</p></FeatureCase>
-            <FeatureDefault><p>If no conditions are met then render the default</p></FeatureDefault>
+          <FeatureCase condition="aa" allowBreak>
+            <p>Multivariate Test 1 Rendered</p>
+          </FeatureCase>
+          <FeatureCase condition="acc" allowBreak>
+            <p>Multivariate Test 2 Rendered</p>
+          </FeatureCase>
+          <FeatureDefault>
+            <p>If no conditions are met then render the default</p>
+          </FeatureDefault>
         </FeatureSwitch>
       </FeatureFlag>
     );
-    expect(component.exists()).to.equal(true);
+    expect(component.exists()).toBe(true);
+    expect(component.find('FeatureDefault').exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
+  });
+
+  it.only('FeatureFlag: should not render the FeatureSwitch and throw a warning when FeatureSwitch gets mixed with NonPlugin elements', () => {
+    const component = mount(
+      <FeatureFlag appFlags={appFlags} flagKey="switcher">
+        <div id="hello">Hello</div>
+        <FeatureSwitch>
+          <FeatureCase condition="switch" allowBreak>
+            <p>Multivariate Test 1 Rendered</p>
+          </FeatureCase>
+          <FeatureCase condition="a" allowBreak>
+            <p>Multivariate Test 2 Rendered</p>
+          </FeatureCase>
+          <FeatureDefault>
+            <p>If no conditions are met then render the default</p>
+          </FeatureDefault>
+        </FeatureSwitch>
+      </FeatureFlag>
+    );
+    expect(component.exists()).toBe(true);
+    expect(component.find({ id: 'hello' }).exists()).toBe(true);
+    expect(component.debug()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Why?
LD feature flag payload has been changed. This PR updates the plugin to adapt to the change.
Breaking change.
Application Flags from LD used to be like,
```
const applicationKeys = {
  'multivariate-test':  'multivariate-test-2',
  'integration-test':  true
};
```
Now it looks like,
```
const applicationKeys = {
  'multivariate-test': { value: 'multivariate-test-2', version: 1},
  'integration-test': { value: true }
};
```

The aim of this PR is to add the ability to adapt to the new change. 