### PR TITLE
Fix CI build

### DIFF
--- a/src/lib/FeatureSwitch/index.tsx
+++ b/src/lib/FeatureSwitch/index.tsx
@@ -28,7 +28,7 @@ const FeatureSwitch: React.FC<IComponentProps> = (props) => {
 
   React.Children.forEach(children, element => {
     // if the Component is FeatureCase and break is false, compare the feature flag and render the element if its true
-    if (React.isValidElement(element) && element.type === FeatureCase && !breakIt) {
+    if (React.isValidElement(element) && (element as any).type === FeatureCase && !breakIt) {
       // TODO use proper type cast here once they are defined
       const { condition, allowBreak } = (element as any).props;
       if ((appFlags[flagKey] && appFlags[flagKey].value) === condition) {
@@ -37,12 +37,12 @@ const FeatureSwitch: React.FC<IComponentProps> = (props) => {
       }
     }
     // if its Default and it is not breaked yet, render the element.
-    if (React.isValidElement(element) && element.type === FeatureDefault && !breakIt) {
+    if (React.isValidElement(element) && (element as any).type === FeatureDefault && !breakIt) {
       childArray.push(element);
     }
   });
 
   return <React.Fragment>{childArray}</React.Fragment>;
-}
+};
 
 export default FeatureSwitch;


### PR DESCRIPTION
# What Changed
Cast `element` to type `any` for comparison.

# Why
Fix TS2367 error.
>This condition will always return `false` since the types have no overlap.

This should also fix the CI build which was failing in stage `yarn docs:build`. Verified locally.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`))