### PR TITLE
Fix Storybook errors by not minifying/uglifying the static build

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -7,6 +7,9 @@
 // to "React Create App". This only has babel loader to load JavaScript.
 
 module.exports = {
+  optimization: {
+    minimize: false
+  },
   plugins: [
     // your custom plugins
   ],


### PR DESCRIPTION


# What Changed

Storybook bug fixed: https://github.com/intuit/LD-React-Components/issues/48

<img width="1178" alt="Screen Shot 2019-10-10 at 9 02 24 PM" src="https://user-images.githubusercontent.com/563568/66621447-7b282000-eba1-11e9-88fc-9edf5994a84f.png">

<img width="696" alt="Screen Shot 2019-10-10 at 9 03 32 PM" src="https://user-images.githubusercontent.com/563568/66621454-82e7c480-eba1-11e9-9d96-9a02721408d6.png">


# Why

All I did was change webpack to not minify the static files and the bug disappears.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`))