### PR TITLE
Fix/payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@storybook/addon-actions": "^5.2.1",
     "@storybook/addon-docs": "^5.3.0-alpha.6",
     "@storybook/addon-info": "^5.2.1",
-    "@storybook/addon-knobs": "^5.2.5",
     "@storybook/addon-links": "^5.2.1",
     "@storybook/addon-notes": "^5.2.1",
     "@storybook/addon-storysource": "^5.2.5",
@@ -110,7 +109,8 @@
   "dependencies": {
     "hash.js": "~1.1.7",
     "ldclient-js": "^2.10.2",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "@storybook/addon-knobs": "^5.2.5"
   },
   "peerDependencies": {
     "react": "^16.10.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "gh-pages": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^24.9.0",
+    "jest-junit": "^9.0.0",
     "jsdom": "15.1.1",
     "jsdom-global": "3.0.2",
     "mkdirp": "^0.5.1",
@@ -107,10 +108,10 @@
     "webpack-dev-server": "^3.8.1"
   },
   "dependencies": {
+    "@storybook/addon-knobs": "^5.2.5",
     "hash.js": "~1.1.7",
     "ldclient-js": "^2.10.2",
-    "prop-types": "^15.7.2",
-    "@storybook/addon-knobs": "^5.2.5"
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
     "react": "^16.10.1",

--- a/src/lib/FeatureFlag/FeatureFlag.stories.jsx
+++ b/src/lib/FeatureFlag/FeatureFlag.stories.jsx
@@ -17,8 +17,8 @@ export default {
 };
 
 const applicationKeys = {
-  'integration-test': { value: true, version: 3 },
-  'multivariate-test': { value: 'multivariate-test-1', version: 5 }
+  'integration-test': true,
+  'multivariate-test': 'multivariate-test-1'
 };
 
 export const standardUsage = () => (
@@ -55,7 +55,7 @@ export const withFeatureTrueAndFeatureFalse = () => (
 
 export const withNesting = () => {
   const flags = {
-    'nested-flag-key': { value: 'nested-flag-key-1', version: 5 }
+    'nested-flag-key': 'nested-flag-key-1'
   };
   return (
     <FeatureFlag flagKey="multivariate-test" appFlags={applicationKeys}>

--- a/src/lib/FeatureFlag/index.js
+++ b/src/lib/FeatureFlag/index.js
@@ -26,7 +26,7 @@ function FeatureFlag(props) {
         return;
       }
       // if the appFlags has the flagKey, render the child
-      if (appFlags[flagKey] && appFlags[flagKey].value) {
+      if (appFlags[flagKey]) {
         childArray.push(element);
       }
       isChildPluginComponent = true;
@@ -43,7 +43,7 @@ function FeatureFlag(props) {
         );
         return;
       }
-      if (!appFlags[flagKey] || (appFlags[flagKey] && !appFlags[flagKey].value)) {
+      if (!appFlags[flagKey]) {
         childArray.push(element);
       }
       isChildPluginComponent = true;
@@ -73,7 +73,7 @@ function FeatureFlag(props) {
     // therefore, we simply render it as its under FeatureTrue
     if (!isChildPluginComponent) {
       isNonPluginComponent = true;
-      if (appFlags[flagKey] && appFlags[flagKey].value) {
+      if (appFlags[flagKey]) {
         childArray.push(element);
       }
     }

--- a/src/lib/FeatureFlag/typescript.tsx
+++ b/src/lib/FeatureFlag/typescript.tsx
@@ -36,7 +36,7 @@ function FeatureFlag({ children, flagKey, appFlags }: FeatureFlagProps) {
           return;
         }
         // if the appFlags has the flagKey, render the child
-        if (appFlags[flagKey] && appFlags[flagKey].value) {
+        if (appFlags[flagKey]) {
           childArray.push(element);
         }
         isChildPluginComponent = true;
@@ -52,7 +52,7 @@ function FeatureFlag({ children, flagKey, appFlags }: FeatureFlagProps) {
           );
           return;
         }
-        if (!appFlags[flagKey] || (appFlags[flagKey] && !appFlags[flagKey].value)) {
+        if (!appFlags[flagKey]) {
           childArray.push(element);
         }
         isChildPluginComponent = true;
@@ -81,7 +81,7 @@ function FeatureFlag({ children, flagKey, appFlags }: FeatureFlagProps) {
       // therefore, we simply render it as its under FeatureTrue
       if (!isChildPluginComponent) {
         isNonPluginComponent = true;
-        if (appFlags[flagKey] && appFlags[flagKey].value) {
+        if (appFlags[flagKey]) {
           childArray.push(element);
         }
       }

--- a/src/lib/FeatureSwitch/index.tsx
+++ b/src/lib/FeatureSwitch/index.tsx
@@ -31,7 +31,7 @@ const FeatureSwitch: React.FC<IComponentProps> = (props) => {
     if (React.isValidElement(element) && (element as any).type === FeatureCase && !breakIt) {
       // TODO use proper type cast here once they are defined
       const { condition, allowBreak } = (element as any).props;
-      if ((appFlags[flagKey] && appFlags[flagKey].value) === condition) {
+      if (appFlags[flagKey] === condition) {
         childArray.push(element);
         breakIt = allowBreak;
       }

--- a/test-reports/jest/results.xml
+++ b/test-reports/jest/results.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="32" failures="0" time="3.328">
+  <testsuite name="Launch Darkly:" errors="0" failures="0" skipped="0" timestamp="2019-11-13T16:25:38" time="1.262" tests="23">
+    <testcase classname="Launch Darkly: init" name="Launch Darkly: init" time="0.008">
+    </testcase>
+    <testcase classname="Launch Darkly: init without option should throw warning" name="Launch Darkly: init without option should throw warning" time="0.039">
+    </testcase>
+    <testcase classname="Launch Darkly: initPromise" name="Launch Darkly: initPromise" time="0.014">
+    </testcase>
+    <testcase classname="Launch Darkly: createClient" name="Launch Darkly: createClient" time="0.003">
+    </testcase>
+    <testcase classname="Launch Darkly: createClient accepts underscored user keys" name="Launch Darkly: createClient accepts underscored user keys" time="0.002">
+    </testcase>
+    <testcase classname="Launch Darkly: createClient no user" name="Launch Darkly: createClient no user" time="0.002">
+    </testcase>
+    <testcase classname="Launch Darkly: createClient no client key" name="Launch Darkly: createClient no client key" time="0">
+    </testcase>
+    <testcase classname="Launch Darkly: createClient no user authID key" name="Launch Darkly: createClient no user authID key" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents" name="Launch Darkly: handleEvents" time="0.003">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents promise" name="Launch Darkly: handleEvents promise" time="0.013">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents no client" name="Launch Darkly: handleEvents no client" time="0.003">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents no client with reject callback" name="Launch Darkly: handleEvents no client with reject callback" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents timeout with reject callback" name="Launch Darkly: handleEvents timeout with reject callback" time="0.006">
+    </testcase>
+    <testcase classname="Launch Darkly: handleEvents error event" name="Launch Darkly: handleEvents error event" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: getFeatureFlag throws and error when there is no default value provided" name="Launch Darkly: getFeatureFlag throws and error when there is no default value provided" time="0.014">
+    </testcase>
+    <testcase classname="Launch Darkly: getFeatureFlag returns default value when there is no ldClient but a default value(false) is provided" name="Launch Darkly: getFeatureFlag returns default value when there is no ldClient but a default value(false) is provided" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: getAllFlags returns an empty object if the ldclient doesn&apos;t exist" name="Launch Darkly: getAllFlags returns an empty object if the ldclient doesn&apos;t exist" time="0.002">
+    </testcase>
+    <testcase classname="Launch Darkly: LD API initializes with appropriate api" name="Launch Darkly: LD API initializes with appropriate api" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: LD API returns promise that will return a ready client" name="Launch Darkly: LD API returns promise that will return a ready client" time="0.011">
+    </testcase>
+    <testcase classname="Launch Darkly: LD API returns promise that rejects if the client does not initialize in time" name="Launch Darkly: LD API returns promise that rejects if the client does not initialize in time" time="0.003">
+    </testcase>
+    <testcase classname="Launch Darkly: getFeatureFlag returns the feature value" name="Launch Darkly: getFeatureFlag returns the feature value" time="0.005">
+    </testcase>
+    <testcase classname="Launch Darkly: getPromiseFeatureFlag returns reject when there is no default value is provided" name="Launch Darkly: getPromiseFeatureFlag returns reject when there is no default value is provided" time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly: getAllFlags returns all flags belonging to that userKey" name="Launch Darkly: getAllFlags returns all flags belonging to that userKey" time="0.001">
+    </testcase>
+  </testsuite>
+  <testsuite name="Launch Darkly Plugin " errors="0" failures="0" skipped="0" timestamp="2019-11-13T16:25:38" time="2.065" tests="9">
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should render component if flagKey value is true in appFlags object " name="Launch Darkly Plugin  FeatureFlag: should render component if flagKey value is true in appFlags object " time="0.014">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should not render component if flagKey value is false in appFlags object " name="Launch Darkly Plugin  FeatureFlag: should not render component if flagKey value is false in appFlags object " time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should not render component if flagKey does not exist in appFlags object " name="Launch Darkly Plugin  FeatureFlag: should not render component if flagKey does not exist in appFlags object " time="0.001">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should render only the FeatureTrue when flagKey value is true" name="Launch Darkly Plugin  FeatureFlag: should render only the FeatureTrue when flagKey value is true" time="0.038">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should render only the FeatureFalse when flagKey value is false" name="Launch Darkly Plugin  FeatureFlag: should render only the FeatureFalse when flagKey value is false" time="0.006">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should not render either FeatureTrue or FeatureFalse when it gets mixed with NonPluginElement and should throw a warnring" name="Launch Darkly Plugin  FeatureFlag: should not render either FeatureTrue or FeatureFalse when it gets mixed with NonPluginElement and should throw a warnring" time="0.015">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureSwitch: renders the FeatureCase component that matches the flagKey " name="Launch Darkly Plugin  FeatureSwitch: renders the FeatureCase component that matches the flagKey " time="0.023">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureSwitch: renders the FeatureDefault component when the no FeatureCase found that matches the flagKey " name="Launch Darkly Plugin  FeatureSwitch: renders the FeatureDefault component when the no FeatureCase found that matches the flagKey " time="0.003">
+    </testcase>
+    <testcase classname="Launch Darkly Plugin  FeatureFlag: should not render the FeatureSwitch and throw a warning when FeatureSwitch gets mixed with NonPlugin elements" name="Launch Darkly Plugin  FeatureFlag: should not render the FeatureSwitch and throw a warning when FeatureSwitch gets mixed with NonPlugin elements" time="0.01">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/react.test.js
+++ b/test/react.test.js
@@ -13,24 +13,9 @@ import {
 Enzyme.configure({ adapter: new Adapter() });
 
 const appFlags = {
-  a: {
-    value: true,
-    version: 4,
-    variation: 0,
-    trackEvents: false
-  },
-  b: {
-    value: false,
-    version: 5,
-    variation: 0,
-    trackEvents: false
-  },
-  switcher: {
-    value: 'switch',
-    version: 5,
-    variation: 0,
-    trackEvents: false
-  }
+  a: true,
+  b: false,
+  switcher: 'switch'
 };
 
 describe('Launch Darkly Plugin ', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7864,6 +7864,17 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-9.0.0.tgz#9eb247dda7a8d2e1647a92f58a03a1490c74aea5"
+  integrity sha512-jnABGjL5pd2lhE1w3RIslZSufFbWQZGx8O3eluDES7qKxQuonXMtsPIi+4AKl4rtjb4DvMAjwLi4eHukc2FP/Q==
+  dependencies:
+    jest-validate "^24.9.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^5.2.0"
+    uuid "^3.3.3"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -12873,7 +12884,7 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2, uuid@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.3.tgz#4568f0216e78760ee1dbf3a4d2cf53e224112866"
   integrity sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==
@@ -13325,6 +13336,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.1.1:
   version "2.2.0"


### PR DESCRIPTION
Fix the app flag payload. 
Before the FeatureFlag component expect an appFlag something like
```
const appFlag = {
       'profile-view': { value: true, version: 4},
       'add-link': { value: false, version: 2}
}
```
However, this is not what launch darkly API returns in most cases. 

So we will be forced to revert the payload value to
```
const appFlag = {
       'profile-view': true
       'add-link': false
}
```

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`))