### PR TITLE
Changing the entry to the index.js instead of .ts

### DIFF
--- a/API/index.js
+++ b/API/index.js
@@ -1,2 +1,2 @@
-var LDApi = require('../dist/LaunchDarklyClient/index.ts');
+var LDApi = require('../dist/LaunchDarklyClient/index.js');
 module.exports = new LDApi();


### PR DESCRIPTION
# What Changed
Entry points to index.js instead of index.ts
# Why
Now we have made the change to compile and output commonJS files, we should change the entry so that it points to index.js.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`))